### PR TITLE
Add importable generate_noisy_data and tests

### DIFF
--- a/kalman.py
+++ b/kalman.py
@@ -1,0 +1,20 @@
+import math
+import random
+from typing import List
+
+def _matmul(A: List[List[float]], x: List[float]) -> List[float]:
+    return [sum(A[i][j] * x[j] for j in range(len(x))) for i in range(len(A))]
+
+def generate_noisy_data(A: List[List[float]], x: List[float], vals: int, sigma: float) -> List[List[float]]:
+    """Generate noisy position measurements without external dependencies."""
+    data = [[0.0, 0.0] for _ in range(vals)]
+    state = x[:]
+    for i in range(vals):
+        state = _matmul(A, state)
+        rnd1 = random.random()
+        rnd2 = random.random()
+        data[i][0] = state[0] + sigma * math.sqrt(-2.0 * math.log(rnd1)) * math.sin(2.0 * math.pi * rnd2)
+        rnd1 = random.random()
+        rnd2 = random.random()
+        data[i][1] = state[1] + sigma * math.sqrt(-2.0 * math.log(rnd1)) * math.sin(2.0 * math.pi * rnd2)
+    return data

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[tool.pytest.ini_options]
+addopts = "-ra"
+testpaths = ["tests"]

--- a/pytest
+++ b/pytest
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+import importlib.util
+import pathlib
+import sys
+
+
+def main(argv=None):
+    argv = argv or sys.argv[1:]
+    failed = False
+    for path in pathlib.Path('tests').rglob('test_*.py'):
+        spec = importlib.util.spec_from_file_location(path.stem, path)
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        for name in dir(mod):
+            if name.startswith('test_') and callable(getattr(mod, name)):
+                try:
+                    getattr(mod, name)()
+                    print(f"{path}:{name} PASSED")
+                except AssertionError as e:
+                    failed = True
+                    print(f"{path}:{name} FAILED: {e}")
+    sys.exit(1 if failed else 0)
+
+if __name__ == '__main__':
+    main()
+

--- a/tests/test_generate_noisy_data.py
+++ b/tests/test_generate_noisy_data.py
@@ -1,0 +1,18 @@
+from kalman import generate_noisy_data
+
+
+def test_generate_noisy_data_shape():
+    dT = 1
+    A = [
+        [1, 0, dT, 0],
+        [0, 1, 0, dT],
+        [0, 0, 1, 0],
+        [0, 0, 0, 1],
+    ]
+    x = [0, 0, 1, 1]
+    vals = 5
+    sigma = 0.1
+    data = generate_noisy_data(A, x, vals, sigma)
+    assert len(data) == vals
+    assert all(len(row) == 2 for row in data)
+


### PR DESCRIPTION
## Summary
- move `generate_noisy_data` to new `kalman.py`
- add lightweight test runner and `pyproject.toml`
- create tests for `generate_noisy_data`

## Testing
- `./pytest`
